### PR TITLE
adding origin config and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a FastAPI backend for IELTS writing assessment with PostgreSQL integration. The API provides endpoints for user management and writing evaluation services.
+
+## Development Commands
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run development server
+uvicorn main:app --reload
+
+# Database migrations (when enabled)
+alembic revision --autogenerate -m "description"
+alembic upgrade head
+```
+
+## Architecture
+
+### Project Structure
+- **Routes**: `src/routes/` - API endpoints organized by feature (users, write)
+- **Models**: `src/models/` - SQLAlchemy database models  
+- **Schemas**: `src/schemas/` - Pydantic validation schemas for request/response
+- **Core**: `src/core/` - Database configuration, utilities, logging
+
+### API Design
+- **FastAPI** with automatic OpenAPI documentation
+- **Pydantic schemas** for strict validation and serialization
+- **Async/await** patterns throughout for database operations
+- **CORS** configured for `http://localhost:8080` and `https://essay-buddy-ielts.lovable.app`
+
+### Database Architecture
+- **PostgreSQL** with SQLAlchemy async ORM (currently commented out)
+- Models use declarative base pattern
+- Database session management through AsyncSession
+- Alembic for schema migrations (configured but not active)
+
+### IELTS Writing Assessment
+The core feature is the `/write/review` endpoint which:
+- Accepts `WritingInput` with essay content, question details, timing data
+- Returns structured `AIReview` with IELTS band scores (0-9 in 0.5 increments)
+- Validates scores for four IELTS criteria: Task Response, Coherence & Cohesion, Lexical Resource, Grammatical Range & Accuracy
+- Currently returns static mock data - AI integration pending
+
+### Key Dependencies
+- **FastAPI** + **uvicorn** for async web framework
+- **SQLAlchemy** + **asyncpg** for PostgreSQL async operations  
+- **Pydantic** for data validation and serialization
+- **Alembic** for database migrations
+- **python-dotenv** for environment configuration
+
+## Development Notes
+
+### Current State
+- Database connection is commented out in `main.py` and `src/core/db.py`
+- User routes reference undefined `db` variable (needs MongoDB or PostgreSQL implementation)
+- Write review endpoint returns hardcoded response
+- Models are defined but not connected to active database
+
+### CORS Configuration  
+CORS middleware in `main.py:10-21` allows requests from frontend applications with credentials enabled.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# IELTS Writing Assessment Backend
+
+A FastAPI-based backend service for IELTS writing assessment and evaluation.
+
+## Features
+
+- 🔍 **Writing Assessment**: Automated IELTS writing evaluation with detailed scoring
+- 👤 **User Management**: User registration and profile management
+- 📊 **IELTS Scoring**: Comprehensive band scoring across four criteria
+- 🌐 **CORS Support**: Configured for frontend integration
+- ⚡ **Async Operations**: High-performance async database operations
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.8+
+- PostgreSQL (optional, currently disabled)
+
+### Installation
+
+1. Clone the repository:
+```bash
+git clone <repository-url>
+cd ielts-backend
+```
+
+2. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+3. Set up environment variables:
+```bash
+cp .env.example .env
+# Edit .env with your configuration
+```
+
+4. Run the development server:
+```bash
+uvicorn main:app --reload
+```
+
+The API will be available at `http://localhost:8000`
+
+## API Documentation
+
+Once the server is running, visit:
+- **Interactive docs**: http://localhost:8000/docs
+- **ReDoc**: http://localhost:8000/redoc
+
+## API Endpoints
+
+### Health Check
+- `GET /` - Root endpoint
+- `GET /health` - Health check
+
+### Users
+- `POST /users/` - Create a new user
+- `GET /users/{email}` - Get user by email
+
+### Writing Assessment
+- `POST /write/review` - Submit writing for AI review and scoring
+
+## IELTS Scoring Criteria
+
+The writing assessment evaluates four key areas:
+
+1. **Task Response** (0-9): How well the writing addresses the task
+2. **Coherence & Cohesion** (0-9): Organization and logical flow
+3. **Lexical Resource** (0-9): Vocabulary range and accuracy
+4. **Grammatical Range & Accuracy** (0-9): Grammar complexity and correctness
+
+Scores are given in 0.5 increments (e.g., 6.0, 6.5, 7.0).
+
+## Project Structure
+
+```
+src/
+├── core/           # Core utilities and configuration
+│   ├── config.py   # Configuration settings
+│   ├── db.py       # Database connection
+│   └── utils.py    # Utility functions
+├── models/         # SQLAlchemy models
+│   └── users.py    # User model
+├── routes/         # API route handlers
+│   ├── users.py    # User endpoints
+│   └── write.py    # Writing assessment endpoints
+└── schemas/        # Pydantic schemas
+    ├── user.py     # User validation schemas
+    └── write.py    # Writing assessment schemas
+```
+
+## Development
+
+### Database Migrations (when enabled)
+
+```bash
+# Create migration
+alembic revision --autogenerate -m "description"
+
+# Apply migrations
+alembic upgrade head
+```
+
+### Running Tests
+
+```bash
+# Run tests (when test suite is added)
+pytest
+```
+
+## Environment Variables
+
+Create a `.env` file with:
+
+```env
+DATABASE_URL=postgresql+asyncpg://username:password@localhost/ielts_db
+SECRET_KEY=your-secret-key
+DEBUG=True
+```
+
+## Technology Stack
+
+- **FastAPI** - Modern, fast web framework
+- **SQLAlchemy** - SQL toolkit and ORM
+- **PostgreSQL** - Primary database (asyncpg driver)
+- **Pydantic** - Data validation using Python type hints
+- **Alembic** - Database migration tool
+- **Uvicorn** - ASGI server implementation
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Submit a pull request
+
+## License
+
+[Add your license information here]

--- a/main.py
+++ b/main.py
@@ -1,10 +1,24 @@
 from fastapi import FastAPI
 from src.routes import users
+from fastapi.middleware.cors import CORSMiddleware
 #from src.models.user import Base
 #from src.core.db import engine
 
 app = FastAPI()
 app.include_router(users.users)
+
+origins = [
+    "http://localhost:8080"
+    "https://essay-buddy-ielts.lovable.app"
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # @app.on_event("startup")
 # async def startup():


### PR DESCRIPTION
주요 옵션 설명

allow_origins
허용할 출처(origin) 리스트. 

allow_credentials
True이면 브라우저에서 쿠키나 인증 정보를 포함해서 요청 가능.

allow_methods
["*"] → 모든 HTTP 메서드 허용.
특정만 원하면 ["GET", "POST"] 처럼 제한 가능.

allow_headers
요청 헤더 허용 목록. 보통 ["*"] 로 많이 둠